### PR TITLE
Compatibility with BSD date

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ This command line tool (Bash script) helps building RFC 9116 compliant, valid
 & well formatted security.txt files as well as automating the PGP signing &
 expire date updating process.
 
+Requires Bash >= 4.0. Compatible with both GNU coreutils & BSD `date`.
+
 ### Usage
 
 ```bash

--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -100,8 +100,8 @@ else
   GREPABLE_KEY=${KEY//0x/}
   FP=$(echo "$KEY_INFO" | grep -i "$GREPABLE_KEY" | sed -e 's/[^A-F0-9]//g')
   KEY="0x${FP}"
-  if ! [[ "${KEY}" = "0x$(echo "${GREPABLE_KEY}" | tr '[:lower:]' '[:upper:]')" ]]; then
-    echo -e "\033[0;33mEXPANDED 0x$(echo "${GREPABLE_KEY}" | tr '[:lower:]' '[:upper:]') TO ${KEY}\033[0;0m"
+  if ! [[ "${KEY}" = "0x$(echo "${GREPABLE_KEY}" | awk '{print toupper($0)}')" ]]; then
+    echo -e "\033[0;33mEXPANDED 0x$(echo "${GREPABLE_KEY}" | awk '{print toupper($0)}') TO ${KEY}\033[0;0m"
   fi
 fi
 

--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -122,8 +122,8 @@ else
   GREPABLE_KEY=${KEY//0x/}
   FP=$(echo "$KEY_INFO" | grep -i "$GREPABLE_KEY" | sed -e 's/[^A-F0-9]//g')
   KEY="0x${FP}"
-  if ! [[ "${KEY}" = "0x$(echo "${GREPABLE_KEY}" | awk '{print toupper($0)}')" ]]; then
-    echo -e "\033[0;33mEXPANDED 0x$(echo "${GREPABLE_KEY}" | awk '{print toupper($0)}') TO ${KEY}\033[0;0m"
+  if ! [[ "${KEY}" = "0x${GREPABLE_KEY^^}" ]]; then
+    echo -e "\033[0;33mEXPANDED 0x${GREPABLE_KEY^^} TO ${KEY}\033[0;0m"
   fi
 fi
 

--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -52,6 +52,12 @@ required_command() {
 
 UNMET=0
 
+if ((BASH_VERSINFO[0] < 4)); then
+  echo -e "\033[0;31mThis script requires bash >= 4.0\033[0m" >&2
+  echo -e "\033[0;31mYour bash ${BASH_VERSION} is unsupported.\033[0m" >&2
+  ((UNMET=UNMET+1))
+fi
+
 required_command "sed"
 required_command "awk"
 required_command "grep"

--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -81,14 +81,25 @@ if ! [[ "$KEY" =~ ^0x[a-fA-F0-9]{8,40}$ ]]; then
 else
   KEY_INFO=$(gpg --list-secret-keys "$KEY" 2> >(sed $'s,.*,\e[33m&\e[m,'>&2))
 
-  KEY_EXPIRES=$(
-    echo "$KEY_INFO" \
-      | grep "sec" \
-      | grep -Eo 'expires:\ [0-9\-]+' \
-      | awk '{ print $2}' \
-      | ( (( IS_MAC )) && date -Iseconds -u || date -Iseconds -u -f - ) \
-      | sed -e 's/+00:00$/Z/'
-    )
+  if (( IS_MAC )); then
+    KEY_EXPIRES=$(
+      echo "$KEY_INFO" \
+        | grep "sec" \
+        | grep -Eo 'expires:\ [0-9\-]+' \
+        | awk '{ print $2}' \
+        | date -Iseconds -u \
+        | sed -e 's/+00:00$/Z/'
+      )
+  else
+    KEY_EXPIRES=$(
+      echo "$KEY_INFO" \
+        | grep "sec" \
+        | grep -Eo 'expires:\ [0-9\-]+' \
+        | awk '{ print $2}' \
+        | date -Iseconds -u -f - \
+        | sed -e 's/+00:00$/Z/'
+      )
+  fi
   echo
 
   if [[ "$KEY_EXPIRES" = "" ]]; then

--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -35,7 +35,7 @@ fi
 
 # Prepare environment
 
-[[ "$(uname)" == "Darwin" ]] && IS_MAC=true || IS_MAC=false
+[[ "$(uname)" == "Darwin" ]] && IS_MAC=1 || IS_MAC=0
 
 # Check for requirements. Print all unmet requirements at once.
 
@@ -86,7 +86,7 @@ else
       | grep "sec" \
       | grep -Eo 'expires:\ [0-9\-]+' \
       | awk '{ print $2}' \
-      | ( [[ IS_MAC ]] && date -Iseconds -u || date -Iseconds -u -f - ) \
+      | ( (( IS_MAC )) && date -Iseconds -u || date -Iseconds -u -f - ) \
       | sed -e 's/+00:00$/Z/'
     )
   echo
@@ -119,7 +119,7 @@ fi
 # Set expire date. 
 # If the key expires before the DAYS_MAX, use the key expiration date instead.
 
-if [[ IS_MAC ]]; then
+if (( IS_MAC )); then
   EXPIRES=$(date -Iseconds -u -v+${DAYS_MAX}d | sed -e 's/+00:00$/Z/')
 else
   EXPIRES=$(date -Iseconds -u -d "${DAYS_MAX} days" | sed -e 's/+00:00$/Z/')
@@ -128,7 +128,7 @@ fi
 if [ -z ${KEY_EXPIRES+x} ]; then 
   echo -e "\033[0;33mUSING EXPIRE (max ${DAYS_MAX} days): $EXPIRES\033[0;0m"
 else
-  if [[ IS_MAC ]]; then
+  if (( IS_MAC )); then
     EXPIRES_COMPARABLE=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$EXPIRES" +%s)
     KEY_EXPIRES_COMPARABLE=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$KEY_EXPIRES" +%s)
   else


### PR DESCRIPTION
The macOS shell has a different date format and does not support the uppercase shortcut.