### PR TITLE
Force loopback pinentry-mode

### DIFF
--- a/securitytxt-signer.sh
+++ b/securitytxt-signer.sh
@@ -404,7 +404,7 @@ echo -e '\033[0;33m---\033[0m'
 
 echo "$FORMATTED" \
   | gpg --clearsign --digest-algo SHA512 \
-    --local-user "$KEY" --output "$OUTFILE" \
+    --local-user "$KEY" --pinentry-mode loopback  --output "$OUTFILE" \
   2> >(sed $'s,.*,\e[33m&\e[m,'>&2) \
   || exit 1
 


### PR DESCRIPTION
Fixes an issue with GPG:

gpg: signing failed: Inappropriate ioctl for device
gpg: [stdin]: clear-sign failed: Inappropriate ioctl for device